### PR TITLE
Integrate Spring Data MongoDB Reactive repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,13 +33,15 @@ dependencies {
 	compile "org.springframework.reactive:spring-reactive:0.1.0.BUILD-SNAPSHOT"
 	compile "com.fasterxml.jackson.core:jackson-databind:2.7.3"
 
+	compile "org.springframework.data:spring-data-mongodb:2.0.0.DATAMONGO-1444-SNAPSHOT"
+
 	compile "io.projectreactor:reactor-netty:2.5.0.BUILD-SNAPSHOT"
 
-	compile "org.mongodb:mongodb-driver-reactivestreams:1.1.0"
+	compile "org.mongodb:mongodb-driver-reactivestreams:1.2.0"
 	compile "com.couchbase.client:java-client:2.2.2"
 	compile "com.github.alaisi.pgasync:postgres-async-driver:0.7"
 
-	compile "org.slf4j:slf4j-jcl:1.7.12"
+	compile "org.slf4j:slf4j-log4j12:1.7.12"
 	compile "org.slf4j:jul-to-slf4j:1.7.12"
 	compile("log4j:log4j:1.2.16")
 

--- a/src/main/java/playground/mongo/MongoPersonController.java
+++ b/src/main/java/playground/mongo/MongoPersonController.java
@@ -18,7 +18,6 @@ package playground.mongo;
 
 import org.reactivestreams.Publisher;
 import playground.Person;
-import playground.repository.ReactiveRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -31,32 +30,33 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * @author Sebastien Deleuze
+ * @author Mark Paluch
  */
 @Profile("mongo")
 @RestController
 public class MongoPersonController {
 
-	private final ReactiveRepository<Person> repository;
+	private final ReactiveMongoPersonRepository repository;
 
 	@Autowired
-	public MongoPersonController(MongoPersonRepository repository) {
+	public MongoPersonController(ReactiveMongoPersonRepository repository) {
 		this.repository = repository;
 	}
 
 	@RequestMapping(path = "/mongo", method = RequestMethod.POST)
 	public Mono<Void> create(@RequestBody Publisher<Person> personStream) {
-		return this.repository.insert(personStream);
+		return this.repository.save(personStream).then();
 	}
 
 	@RequestMapping(path = "/mongo", method = RequestMethod.GET)
 	public Flux<Person> list() {
-		return this.repository.list();
+		return this.repository.findAll();
 	}
 
 	// TODO Manage {@code @PathVariable}
 	@RequestMapping(path = "/mongo/1", method = RequestMethod.GET)
 	public Mono<Person> findById() {
-		return this.repository.findById("1");
+		return this.repository.findOne("1");
 	}
 
 }

--- a/src/main/java/playground/mongo/MongoPersonRepository.java
+++ b/src/main/java/playground/mongo/MongoPersonRepository.java
@@ -62,7 +62,7 @@ public class MongoPersonRepository implements ReactiveRepository<Person> {
 			catch (JsonProcessingException ex) {
 				return Mono.error(ex);
 			}
-		}).after();
+		}).then();
 	}
 
 	@Override

--- a/src/main/java/playground/mongo/ReactiveMongoPersonRepository.java
+++ b/src/main/java/playground/mongo/ReactiveMongoPersonRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package playground.mongo;
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import playground.Person;
+
+/**
+ * @author Mark Paluch
+ */
+public interface ReactiveMongoPersonRepository extends ReactiveCrudRepository<Person, String> {
+
+}

--- a/src/main/java/playground/mongo/ReactiveMongoRxJavaPersonRepository.java
+++ b/src/main/java/playground/mongo/ReactiveMongoRxJavaPersonRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package playground.mongo;
+
+import org.springframework.data.repository.reactive.RxJavaCrudRepository;
+
+import playground.Person;
+
+/**
+ * @author Mark Paluch
+ */
+public interface ReactiveMongoRxJavaPersonRepository extends RxJavaCrudRepository<Person, String> {
+
+}

--- a/src/main/java/playground/mongo/RxJavaMongoPersonController.java
+++ b/src/main/java/playground/mongo/RxJavaMongoPersonController.java
@@ -17,8 +17,6 @@
 package playground.mongo;
 
 import playground.Person;
-import playground.repository.RxJavaRepository;
-import playground.repository.RxJavaRepositoryAdapter;
 import rx.Observable;
 import rx.Single;
 
@@ -31,32 +29,33 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * @author Sebastien Deleuze
+ * @author Mark Paluch
  */
 @Profile("mongo")
 @RestController
 public class RxJavaMongoPersonController {
 
-	private final RxJavaRepository<Person> repository;
+	private final ReactiveMongoRxJavaPersonRepository repository;
 
 	@Autowired
-	public RxJavaMongoPersonController(MongoPersonRepository repository) {
-		this.repository = new RxJavaRepositoryAdapter<>(repository);
+	public RxJavaMongoPersonController(ReactiveMongoRxJavaPersonRepository repository) {
+		this.repository = repository;
 	}
 
 	@RequestMapping(path = "/rxjava/mongo", method = RequestMethod.POST)
-	public Single<Void> create(@RequestBody Observable<Person> personStream) {
-		return this.repository.insert(personStream);
+	public Observable<Person> create(@RequestBody Observable<Person> personStream) {
+		return this.repository.save(personStream);
 	}
 
 	@RequestMapping(path = "/rxjava/mongo", method = RequestMethod.GET)
 	public Observable<Person> list() {
-		return this.repository.list();
+		return this.repository.findAll();
 	}
 
 	// TODO Manage {@code @PathVariable}
 	@RequestMapping(path = "/rxjava/mongo/1", method = RequestMethod.GET)
 	public Single<Person> findById() {
-		return this.repository.findById("1");
+		return this.repository.findOne("1");
 	}
 
 }


### PR DESCRIPTION
This PR integrates with Spring Data MongoDB reactive repositories.

Spring Data exposes reactive repositories using Project Reactor and RxJava types. Spring Data allows RxJava, Project Reactor or mixed repositories.

``` java
public interface ReactiveMongoRxJavaPersonRepository extends RxJavaCrudRepository<Person, String> {

}

public interface ReactiveMongoPersonRepository extends ReactiveCrudRepository<Person, String> {

}

public interface ReactiveMongoRxJavaPersonRepository extends RxJavaCrudRepository<Person, String> {

    Flux<Person> findByLastname(String lastname);

    Single<Person> findByFirstnameAndLastname(String firstname, String lastname);
}

```

---

Spring Data MongoDB Branch: [issue/DATAMONGO-1444](https://github.com/spring-projects/spring-data-mongodb/tree/issue/DATAMONGO-1444)
Requirements: MongoDB ReactiveStreams driver 1.2.0, Project Reactor 2.5.0.M4
Artifact coordinates:

``` xml
<dependency>
    <groupId>org.springframework.data</groupId>
    <artifactId>spring-data-mongodb</artifactId>
    <version>2.0.0.DATAMONGO-1444-SNAPSHOT</version>
</dependency>
```

Please note that the project fails with `HTTP/1.1 500 Internal Server Error` and `Caused by: org.springframework.web.server.UnsupportedMediaTypeStatusException: Request failure [status: 415, reason: "Content type 'application/json' not supported"]`

`PostgresPersonRepository` and `CouchbasePersonRepository` are based on Project Reactor 2.5.0.M3 and need to be migrated from `.after()` to `.then()`.
